### PR TITLE
Reproduction

### DIFF
--- a/tools/cfgs/m3detr_models/m3detr_waymo_1000.yaml
+++ b/tools/cfgs/m3detr_models/m3detr_waymo_1000.yaml
@@ -1,7 +1,7 @@
 CLASS_NAMES: ['Vehicle', 'Pedestrian', 'Cyclist']
 
 DATA_CONFIG:
-    _BASE_CONFIG_: cfgs/dataset_configs/waymo_dataset_val.yaml
+    _BASE_CONFIG_: cfgs/dataset_configs/waymo_dataset.yaml
 
 
 MODEL:

--- a/tools/cfgs/m3detr_models/m3detr_waymo_1500.yaml
+++ b/tools/cfgs/m3detr_models/m3detr_waymo_1500.yaml
@@ -1,7 +1,7 @@
 CLASS_NAMES: ['Vehicle', 'Pedestrian', 'Cyclist']
 
 DATA_CONFIG:
-    _BASE_CONFIG_: cfgs/dataset_configs/waymo_dataset_val.yaml
+    _BASE_CONFIG_: cfgs/dataset_configs/waymo_dataset.yaml
 
 
 MODEL:


### PR DESCRIPTION
Changes required to reproduce advertised results against the Waymo Dataset.

Broad tasks:
 - [ ] : Obtain comparable inference results via pre-trained model `m3detr_waymo_1000`
 - [ ] : Obtain comparable inference results via pre-trained model `m3detr_waymo_1500`
 - [ ] : Demonstrate successful training pipeline (no results evaluation due to hardware limitations)